### PR TITLE
Fix failing socket symlink creation

### DIFF
--- a/listener.go
+++ b/listener.go
@@ -43,7 +43,7 @@ func NewUnixListener() (net.Listener, error) {
 		return nil, err
 	}
 
-	if err := os.MkdirAll(dockerPluginSockDir, 0777); err != nil {
+	if err := os.MkdirAll(dockerPluginSockDir, 0755); err != nil {
 		return nil, err
 	}
 

--- a/listener.go
+++ b/listener.go
@@ -43,6 +43,10 @@ func NewUnixListener() (net.Listener, error) {
 		return nil, err
 	}
 
+	if err := os.MkdirAll(dockerPluginSockDir, 0777); err != nil {
+		return nil, err
+	}
+
 	fullDwgdSockPath := path.Join(dwgdRunDir, dwgdSockName)
 	listener, err := sockets.NewUnixSocket(fullDwgdSockPath, 0)
 	if err != nil {


### PR DESCRIPTION
Fixes #2 by creating the missing folder. This does not seem to interfere with normal docker daemon startup.