### PR TITLE
Use gateway specified on command line "docker network create"

### DIFF
--- a/driver.go
+++ b/driver.go
@@ -315,3 +315,13 @@ func (d *Driver) Leave(r *network.LeaveRequest) error {
 
 	return nil
 }
+
+func (d *Driver) ProgramExternalConnectivity(r *network.ProgramExternalConnectivityRequest) error {
+	TraceLog.Printf("ProgramExternalConnectivity(): [ %+v ]\n", r)
+	return nil
+}
+
+func (d *Driver) RevokeExternalConnectivity(r *network.RevokeExternalConnectivityRequest) error {
+	TraceLog.Printf("RevokeExternalConnectivity(): [ %+v ]\n", r)
+	return nil
+}

--- a/migrations/0002.sql
+++ b/migrations/0002.sql
@@ -1,0 +1,2 @@
+ALTER TABLE network ADD COLUMN gateway TEXT;
+ALTER TABLE network ADD COLUMN gateway_v6 TEXT;


### PR DESCRIPTION
Currently dwgd doesn't set a default route and when it does set it using `dwgd.route` option, docker gets confused. Allow setting a default route using `docker network create ... --gateway <IP>`.

Copying from Issue #4, for context

```
The problem with the current implementation is that the routes are added as static routes, but docker doesn't understand it is 
dealing with a default route. Because of that, if you add another network to a container - for example a bridge, docker will see 
that the dwgd network doesn't provide a default route and will create a default route via the other network. You'll get an 
annoying message saying the container wasn't able to be created because 0.0.0.0/0 already exists. Currently dwgd doesn't use 
the gateway parameter, even though it is specified in the documentation as the way to create the network.
```